### PR TITLE
(feat) CAPI clusters

### DIFF
--- a/controllers/rolerequest_controller.go
+++ b/controllers/rolerequest_controller.go
@@ -65,6 +65,8 @@ type RoleRequestReconciler struct {
 	ConcurrentReconciles int
 	Deployer             deployer.DeployerInterface
 
+	CapiOnboardAnnotation string // when set, only capi clusters with this annotation are considered
+
 	// key: RoleRequest; value RoleRequest Selector
 	RoleRequests map[corev1.ObjectReference]libsveltosv1beta1.Selector
 
@@ -465,7 +467,8 @@ func (r *RoleRequestReconciler) getCurrentReferences(roleRequestScope *scope.Rol
 func (r *RoleRequestReconciler) getMatchingClusters(ctx context.Context, roleRequestScope *scope.RoleRequestScope,
 	logger logr.Logger) ([]corev1.ObjectReference, error) {
 
-	matchingCluster, err := clusterproxy.GetMatchingClusters(ctx, r.Client, roleRequestScope.GetSelector(), "", logger)
+	matchingCluster, err := clusterproxy.GetMatchingClusters(ctx, r.Client, roleRequestScope.GetSelector(), "",
+		r.CapiOnboardAnnotation, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
 	github.com/pkg/errors v0.9.1
-	github.com/projectsveltos/libsveltos v0.48.1
+	github.com/projectsveltos/libsveltos v0.48.2-0.20250223175100-10c112233d48
 	github.com/prometheus/client_golang v1.20.5
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/text v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/projectsveltos/libsveltos v0.48.1 h1:SWtACXeVNehWNxh/jEeFB/Z1QqMd4HeSh5Z60czwJbQ=
-github.com/projectsveltos/libsveltos v0.48.1/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223175100-10c112233d48 h1:Udx7sQfiD3CqW00dS4me0GMrEDUcvquYhASiqqFLiuM=
+github.com/projectsveltos/libsveltos v0.48.2-0.20250223175100-10c112233d48/go.mod h1:9z2AUhSE2qzi+m5tqeQUMm+c4whMtbKH6oYOYY+0tbw=
 github.com/prometheus/client_golang v1.20.5 h1:cxppBPuYhUnsO6yo/aoRol4L7q7UFfdm+bR9r+8l63Y=
 github.com/prometheus/client_golang v1.20.5/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=

--- a/main.go
+++ b/main.go
@@ -59,16 +59,17 @@ import (
 )
 
 var (
-	setupLog             = ctrl.Log.WithName("setup")
-	diagnosticsAddress   string
-	insecureDiagnostics  bool
-	concurrentReconciles int
-	workers              int
-	restConfigQPS        float32
-	restConfigBurst      int
-	webhookPort          int
-	syncPeriod           time.Duration
-	healthAddr           string
+	setupLog              = ctrl.Log.WithName("setup")
+	diagnosticsAddress    string
+	insecureDiagnostics   bool
+	concurrentReconciles  int
+	workers               int
+	restConfigQPS         float32
+	restConfigBurst       int
+	webhookPort           int
+	syncPeriod            time.Duration
+	healthAddr            string
+	capiOnboardAnnotation string
 )
 
 const (
@@ -142,6 +143,7 @@ func main() {
 		Client:                  mgr.GetClient(),
 		Scheme:                  mgr.GetScheme(),
 		Deployer:                d,
+		CapiOnboardAnnotation:   capiOnboardAnnotation,
 		RoleRequests:            make(map[corev1.ObjectReference]libsveltosv1beta1.Selector),
 		ClusterMap:              make(map[corev1.ObjectReference]*libsveltosset.Set),
 		RoleRequestClusterMap:   make(map[corev1.ObjectReference]*libsveltosset.Set),
@@ -201,6 +203,9 @@ func initFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&healthAddr, "health-addr", ":9440",
 		"The address the health endpoint binds to.")
+
+	fs.StringVar(&capiOnboardAnnotation, "capi-onboard-annotation", "",
+		"If provided, Sveltos will only manage CAPI clusters that have this exact annotation.")
 
 	const defautlRestConfigQPS = 20
 	fs.Float32Var(&restConfigQPS, "kube-api-qps", defautlRestConfigQPS,


### PR DESCRIPTION
access-manager can be passed a new arg: `capi-onboard-annotation`. It allows administrators to specify a custom annotation key. When this annotation is set, Sveltos will only manage CAPI clusters that have this specific annotation with any value.

CAPI clusters without this annotation will be ignored by Sveltos.